### PR TITLE
Pull in changes from https://github.com/clj-commons/iapetos/pull/19

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ These are, purposefully, compatible with the metrics produced by
 [prometheus-clj](https://github.com/soundcloud/prometheus-clj), as to allow a
 smooth migration.
 
+Ring supports sync and async [handlers](https://github.com/ring-clojure/ring/wiki/Concepts#handlers), metrics are collected for both by `iapetos.collector.ring` ns.
+
 #### Exception Handling <a name="exception-handling"></a>
 
 By default, if your ring handler throws an exception, only the `http_exceptions_total` counter would be incremented.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-commons/iapetos "0.1.11b"
+(defproject earth.cervest/iapetos "0.1.12"
   :description "A Clojure Prometheus Client"
   :url "https://github.com/clj-commons/iapetos"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-commons/iapetos "0.1.11"
+(defproject clj-commons/iapetos "0.1.11b"
   :description "A Clojure Prometheus Client"
   :url "https://github.com/clj-commons/iapetos"
   :license {:name "MIT License"
@@ -32,4 +32,8 @@
                              [riddley "0.1.15"]]}}
   :aliases {"codox" ["with-profile" "+codox" "codox"]
             "codecov" ["with-profile" "+coverage" "cloverage" "--codecov"]}
-  :pedantic? :abort)
+  :deploy-repositories {"releases" {:url           "s3p://cervest-internal-jars/releases"
+                                    :sign-releases false
+                                    :no-auth       true}}
+  :lein-release {:deploy-via "releases"}
+  :plugins [[s3-wagon-private "1.3.4"]])

--- a/test/iapetos/collector/ring_test.clj
+++ b/test/iapetos/collector/ring_test.clj
@@ -11,66 +11,92 @@
 
 ;; ## Generators
 
-(defn- status-labels 
+(defn- status-labels
   [status]
   {:status      (str status)
-   :statusClass (str (quot status 100) "XX")}) 
+   :statusClass (str (quot status 100) "XX")})
 
 (def gen-handler
-  (gen/one-of
-    [(gen/let [status (gen/elements
-                        (concat
-                          (range 200 205)
-                          (range 300 308)
-                          (range 400 429)
-                          (range 500 505)))]
-       (gen/return
-         {:handler (constantly {:status status})
-          :exception? false
-          :labels (status-labels status)}))
-     (gen/return
+  (gen/let [status (gen/elements
+                    (concat
+                     (range 200 205)
+                     (range 300 308)
+                     (range 400 429)
+                     (range 500 505)))]
+    (gen/one-of
+     [(gen/return
+       {:handler    (constantly {:status status})
+        :async?     false
+        :exception? false
+        :labels     {:status      (str status)
+                     :statusClass (str (quot status 100) "XX")}})
+      (gen/return
+       {:handler    (fn [_ respond _] (deliver respond {:status status}))
+        :async?     true
+        :exception? false
+        :labels     {:status      (str status)
+                     :statusClass (str (quot status 100) "XX")}})
+      (gen/return
+       {:handler    (fn [_ _ raise] (deliver raise (Exception.)))
+        :async?     true
+        :exception? true})
+      (gen/return
        {:handler    (fn [_] (throw (Exception.)))
-        :exception? true})]))
+        :async?     false
+        :exception? true})])))
 
 (def gen-request
   (gen/let [path   (gen/fmap #(str "/" %) gen/string-alpha-numeric)
             method (gen/elements [:get :post :put :delete :patch :options :head])]
     (gen/return
-      {:request-method method
-       :uri            path
-       :labels         {:method (-> method name .toUpperCase)
-                        :path   path}})))
+     {:request-method method
+      :uri            path
+      :labels         {:method (-> method name .toUpperCase)
+                       :path   path}})))
+
+(defn async-response [handler request]
+  (let [result (promise)]
+    (handler request #(result [:ok %]) #(result [:fail %]))
+    (if-let [[status value] (deref result 1500 nil)]
+      (if (= status :ok)
+        value
+        ::error))))
+
+(defn sync-response [handler request]
+  (try
+    (handler request)
+    (catch Throwable t
+      ::error)))
 
 ;; ## Tests
 
-(defspec t-wrap-instrumentation 100
+(defspec t-wrap-instrumentation 200
   (prop/for-all
-    [registry-fn                         (g/registry-fn ring/initialize)
-     {:keys [handler exception? labels]} gen-handler
-     {labels' :labels, :as request}      gen-request
-     wrap (gen/elements [ring/wrap-instrumentation ring/wrap-metrics])]
-    (let [registry   (registry-fn)
-          handler'   (wrap handler registry)
-          start-time (System/nanoTime)
-          response   (try
-                       (handler' request)
-                       (catch Throwable t
-                         ::error))
-          delta      (/ (- (System/nanoTime) start-time) 1e9)
-          labels     (merge labels labels')
-          ex-labels  (assoc labels' :exceptionClass "java.lang.Exception")
-          counter    (registry :http/requests-total labels)
-          histogram  (registry :http/request-latency-seconds labels)
-          ex-counter (registry :http/exceptions-total ex-labels)]
-      (if exception?
-        (and (= response ::error)
-             (= 0.0 (prometheus/value counter))
-             (= 0.0 (:count (prometheus/value histogram)))
-             (= 1.0 (prometheus/value ex-counter)))
-        (and (map? response)
-             (= 0.0 (prometheus/value ex-counter))
-             (< 0.0 (:sum (prometheus/value histogram)) delta)
-             (= 1.0 (prometheus/value counter)))))))
+   [registry-fn                                (g/registry-fn ring/initialize)
+    {:keys [handler async? exception? labels]} gen-handler
+    {labels' :labels, :as request}             gen-request
+    wrap                                       (gen/elements [ring/wrap-instrumentation ring/wrap-metrics])]
+   (let [registry   (registry-fn)
+         handler'   (wrap handler registry)
+         start-time (System/nanoTime)
+         response   (if async?
+                      (async-response handler' request)
+                      (sync-response handler' request))
+         delta      (/ (- (System/nanoTime) start-time) 1e9)
+         labels     (merge labels labels')
+         ex-labels  (assoc labels' :exceptionClass "java.lang.Exception")
+         counter    (registry :http/requests-total labels)
+         histogram  (registry :http/request-latency-seconds labels)
+         ex-counter (registry :http/exceptions-total ex-labels)]
+     (if exception?
+       (and (= response ::error)
+            (= 0.0 (prometheus/value counter))
+            (= 0.0 (:count (prometheus/value histogram)))
+            (= 1.0 (prometheus/value ex-counter)))
+       (and (map? response)
+            (= 0.0 (prometheus/value ex-counter))
+            (< 0.0 (:sum (prometheus/value histogram)) delta)
+            (= 1.0 (prometheus/value counter)))))))
 
 (defspec t-wrap-instrumentation-with-exception-status 10
   (prop/for-all
@@ -79,7 +105,7 @@
      {labels' :labels, :as request}      gen-request
      wrap (gen/elements [ring/wrap-instrumentation ring/wrap-metrics])]
     (let [registry   (registry-fn)
-          ex-status  500 
+          ex-status  500
           handler'   (wrap handler registry {:exception-status ex-status})
           start-time (System/nanoTime)
           response   (try
@@ -103,66 +129,75 @@
 
 (defspec t-wrap-metrics-expose 10
   (prop/for-all
-    [registry-fn (g/registry-fn ring/initialize)
-     path        (gen/fmap #(str "/" %) gen/string-alpha-numeric)
-     wrap        (gen/elements [ring/wrap-metrics-expose ring/wrap-metrics])]
-    (let [registry (registry-fn)
-          handler (-> (constantly {:status 200})
-                      (wrap registry {:path path}))]
-      (and (= {:status 200}
-              (handler {:request-method :get,  :uri (str path "__/health")}))
-           (= {:status 405}
-              (handler {:request-method :post, :uri path}))
-           (let [{:keys [status headers body]}
-                 (handler {:request-method :get, :uri path})]
-             (and (= 200 status)
-                  (contains? headers "Content-Type")
-                  (re-matches #"text/plain(;.*)?" (headers "Content-Type"))
-                  (= (export/text-format registry) body)))))))
+   [registry-fn         (g/registry-fn ring/initialize)
+    path                (gen/fmap #(str "/" %) gen/string-alpha-numeric)
+    [handler-fn async?] (gen/elements [[(constantly {:status 200}) false]
+                                       [(fn [_ respond _] (deliver respond {:status 200})) true]])
+    wrap                (gen/elements [ring/wrap-metrics-expose ring/wrap-metrics])]
+   (let [registry    (registry-fn)
+         response-fn (if async? async-response sync-response)
+         handler     (-> handler-fn
+                         (wrap registry {:path path}))]
+     (and (= {:status 200}
+             (response-fn handler {:request-method :get, :uri (str path "__/health")}))
+          (= {:status 405}
+             (response-fn handler {:request-method :post, :uri path}))
+          (let [{:keys [status headers body]}
+                (response-fn handler {:request-method :get, :uri path})]
+            (and (= 200 status)
+                 (contains? headers "Content-Type")
+                 (re-matches #"text/plain(;.*)?" (headers "Content-Type"))
+                 (= (export/text-format registry) body)))))))
 
-(defspec t-wrap-metrics-expose-with-on-request-hook 10
+(defspec t-wrap-metrics-expose-with-on-request-hook 50
   (prop/for-all
-    [registry-fn (g/registry-fn ring/initialize)
-     path        (gen/fmap #(str "/" %) gen/string-alpha-numeric)
-     wrap        (gen/elements [ring/wrap-metrics-expose ring/wrap-metrics])]
-    (let [registry (-> (registry-fn)
-                       (prometheus/register
-                         (prometheus/counter :http/scrape-requests-total)))
-          on-request-fn #(prometheus/inc % :http/scrape-requests-total)
-          handler (-> (constantly {:status 200})
-                      (wrap registry
-                            {:path path
-                             :on-request on-request-fn}))]
-      (and (zero? (prometheus/value (registry :http/scrape-requests-total)))
-           (= 200 (:status (handler {:request-method :get, :uri path})))
-           (= 1.0 (prometheus/value (registry :http/scrape-requests-total)))))))
+   [registry-fn         (g/registry-fn ring/initialize)
+    path                (gen/fmap #(str "/" %) gen/string-alpha-numeric)
+    [handler-fn async?] (gen/elements [[(constantly {:status 200}) false]
+                                       [(fn [_ respond _] (deliver respond {:status 200})) true]])
+    wrap                (gen/elements [ring/wrap-metrics-expose ring/wrap-metrics])]
+   (let [registry      (-> (registry-fn)
+                           (prometheus/register
+                            (prometheus/counter :http/scrape-requests-total)))
+         response-fn   (if async? async-response sync-response)
+         on-request-fn #(prometheus/inc % :http/scrape-requests-total)
+         handler       (-> handler-fn
+                           (wrap registry
+                                 {:path       path
+                                  :on-request on-request-fn}))]
+     (and (zero? (prometheus/value (registry :http/scrape-requests-total)))
+          (= 200 (:status (response-fn handler {:request-method :get, :uri path})))
+          (= 1.0 (prometheus/value (registry :http/scrape-requests-total)))))))
 
-(defspec t-wrap-metrics-with-labels 10
+(defspec t-wrap-metrics-with-labels 50
   (prop/for-all
-    [registry-fn   (g/registry-fn
-                     #(ring/initialize % {:labels [:extraReq :extraResp]}))
-     request-label  (gen/not-empty gen/string-alpha-numeric)
-     response-label (gen/not-empty gen/string-alpha-numeric)
-     wrap           (gen/elements [ring/wrap-metrics ring/wrap-instrumentation])]
-    (let [registry (registry-fn)
-          response {:status       200
-                     :extra-labels {:extraResp response-label}}
-          request  {:request-method :get
-                    :uri            "/"
-                    :extra-labels  {:extraReq request-label}}
-          handler  (-> (constantly response)
-                       (wrap
-                         registry
-                         {:label-fn (fn [request response]
-                                      (merge
+   [registry-fn         (g/registry-fn
+                         #(ring/initialize % {:labels [:extraReq :extraResp]}))
+    [handler-fn async?] (gen/elements [[#(constantly %) false]
+                                       [#(fn [_ respond _] (deliver respond %)) true]])
+    request-label       (gen/not-empty gen/string-alpha-numeric)
+    response-label      (gen/not-empty gen/string-alpha-numeric)
+    wrap                (gen/elements [ring/wrap-metrics ring/wrap-instrumentation])]
+   (let [registry    (registry-fn)
+         response-fn (if async? async-response sync-response)
+         response    {:status       200
+                      :extra-labels {:extraResp response-label}}
+         request     {:request-method :get
+                      :uri            "/"
+                      :extra-labels   {:extraReq request-label}}
+         handler     (-> (handler-fn response)
+                         (wrap
+                          registry
+                          {:label-fn (fn [request response]
+                                       (merge
                                         (:extra-labels request)
                                         (:extra-labels response)))}))
-          labels {:extraReq    request-label
-                  :extraResp   response-label
-                  :status      "200"
-                  :statusClass "2XX"
-                  :method      "GET"
-                  :path        "/"}]
-      (and (zero? (prometheus/value (registry :http/requests-total labels)))
-           (= 200 (:status (handler request)))
-           (= 1.0 (prometheus/value (registry :http/requests-total labels)))))))
+         labels      {:extraReq    request-label
+                      :extraResp   response-label
+                      :status      "200"
+                      :statusClass "2XX"
+                      :method      "GET"
+                      :path        "/"}]
+     (and (zero? (prometheus/value (registry :http/requests-total labels)))
+          (= 200 (:status (response-fn handler request)))
+          (= 1.0 (prometheus/value (registry :http/requests-total labels)))))))


### PR DESCRIPTION
Pulls in https://github.com/clj-commons/iapetos/pull/19, but also fixes most of the merge conflicts with the current master. One of the tests is failing, because the core library has added a form of exception handling since then, and I haven't had the time to dig into what's different.

If fixing the test takes more than an hour, I might just apply the changes I had previously made to cue, which work for async requests. Now is not a good time to go down this rabbit-hole.

